### PR TITLE
Fix unit tests since Bullet is now default double precision

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
     - ROS_REPO=ros
     - NOT_TEST_INSTALL=true
     - CMAKE_ARGS=-DENABLE_TESTS=ON
+    - ROSDEP_SKIP_KEYS="bullet3 fcl benchmark"
     - BUILD_PKGS_WHITELIST="pcs_detection pcs_msgs pcs_ros pcs_scan_integration"
 
 matrix:
@@ -37,7 +38,7 @@ matrix:
     - env: ROS_DISTRO=melodic ROS_REPO=ros-shadow-fixed ROS_PARALLEL_JOBS=-j2 CATKIN_PARALLEL_JOBS=-p3
 
 install:
-  - git clone --quiet --depth=1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci
+  - git clone --quiet --depth 1 https://github.com/ros-industrial/industrial_ci.git .industrial_ci -b legacy
 
 script:
   - .industrial_ci/travis.sh

--- a/dependencies.rosinstall
+++ b/dependencies.rosinstall
@@ -7,6 +7,9 @@
 # Tesseract
 - git: {local-name: tesseract, uri: 'https://github.com/ros-industrial-consortium/tesseract.git', version: master}
 
+# Tesseract External (Bullet)
+- git: {local-name: tesseract_ext, uri: 'https://github.com/ros-industrial-consortium/tesseract_ext.git', version: master}
+
 # Trajopt
 - git: {local-name: trajopt_ros, uri: 'https://github.com/ros-industrial-consortium/trajopt_ros.git', version: master}
 

--- a/pcs_scan_integration/test/octomap_mesh_masking_unit.cpp
+++ b/pcs_scan_integration/test/octomap_mesh_masking_unit.cpp
@@ -167,8 +167,8 @@ TEST_F(OctomapMeshMaskUnit, maskMesh)
       CONSOLE_BRIDGE_logDebug("Saving file to data directory");
     }
     tesseract_geometry::Mesh::Ptr results = masker.getMaskedMesh();
-    EXPECT_EQ(results->getVertices()->size(), 5928);
-    EXPECT_EQ(results->getTriangles()->size(), 1976 * 4);
+    EXPECT_EQ(results->getVertices()->size(), 5925);
+    EXPECT_EQ(results->getTriangles()->size(), 1975 * 4);
   }
   {
     EXPECT_TRUE(masker.maskMesh(OctomapMeshMask::MaskType::RETURN_OUTSIDE));


### PR DESCRIPTION
The unit test tested that the same number of vertices and triangles were returned each time. Since collision checking now uses double precision by default, this changed a small amount along the edges. This updates the the tests to be the correct number